### PR TITLE
compare load with load_crit instead of temp_crit

### DIFF
--- a/check_apcaccess.py
+++ b/check_apcaccess.py
@@ -138,7 +138,7 @@ def check_ups(options):
 
     # check load
     snip_load = check_value(
-        load, "load", options.load_warn, options.temp_crit
+        load, "load", options.load_warn, options.load_crit
     )
 
     # check battery load


### PR DESCRIPTION
Hi,

found this by accident, seems like `load` was compared against `temp_crit` instead of `load_crit`.

Not sure if it's intended, I'm not using check_apcaccess yet.

Regards,
~X